### PR TITLE
fix for laravel nova 3.0

### DIFF
--- a/src/Fields/Notes.php
+++ b/src/Fields/Notes.php
@@ -6,8 +6,9 @@ use Illuminate\Support\Str;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ResourceRelationshipGuesser;
 use DigitalCloud\NovaResourceNotes\Resources\Note;
+use Laravel\Nova\Contracts\RelatableField;
 
-class Notes extends Field {
+class Notes extends Field implements RelatableField {
 
     public $onlyOnDetail = true;
     public $showOnUpdate = false;


### PR DESCRIPTION
Nova viaResource fix for nova throwing a 409 error when trying to load notes on a resource.