### PR TITLE
Allow for satisfaction of all dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "digitalcloud/laravel-model-notes": ">=1.1"
+        "digitalcloud/laravel-model-notes": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Similar to `digitalcloud/laravel-model-notes` dependency on `digitalcloud/laravel-blameable`, allow for wildcard versions of dependency